### PR TITLE
Dont use toJSONString() before putting JSONObject into JSONArray

### DIFF
--- a/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
+++ b/src/main/java/com/redhat/maven/index/checker/MavenIndexChecker.java
@@ -105,12 +105,12 @@ public class MavenIndexChecker {
         mavenIndexChecker.perform();
     }
 
-    private static String toJSON(String artifactId, String groupId, String version) {
+    private static JSONObject toJSON(String artifactId, String groupId, String version) {
         JSONObject obj = new JSONObject();
         obj.put("artifactId", artifactId);
         obj.put("groupId", groupId);
         obj.put("version", version);
-        return obj.toJSONString();
+        return obj;
     }
 
     private static int[] parseRange(String mavenIndexRange) {


### PR DESCRIPTION
You want the output be like:
```
[{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-kernel","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-lucene-index","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-lucene-index","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-lucene-index","version":"1.7.M03"},{"groupId":"org.neo4j","artifactId":"neo4j-lucene-index","version":"1.7.M03"}]
```
not
```
["{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-kernel\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-lucene-index\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-lucene-index\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-lucene-index\",\"version\":\"1.7.M03\"}","{\"groupId\":\"org.neo4j\",\"artifactId\":\"neo4j-lucene-index\",\"version\":\"1.7.M03\"}"]
```